### PR TITLE
Add Support page, Terms of Use, and TestFlight links

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -30,8 +30,19 @@ const description = "Stay aware of how much of the month has passed with MonthBa
         {description}
       </p>
 
-      <!-- App Store Button (Coming Soon) -->
-      <div class="mb-12">
+      <!-- Download Buttons -->
+      <div class="mb-12 flex flex-col sm:flex-row gap-4 justify-center items-center">
+        <a
+          href="https://testflight.apple.com/join/N8n1fSPE"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 px-8 py-4 bg-apple-blue hover:bg-apple-blue/90 text-white rounded-xl font-semibold transition-colors"
+        >
+          <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
+          </svg>
+          Join TestFlight Beta
+        </a>
         <button
           disabled
           class="inline-flex items-center gap-2 px-8 py-4 bg-apple-gray-200 dark:bg-apple-gray-700 text-apple-gray-500 dark:text-apple-gray-400 rounded-xl font-semibold cursor-not-allowed opacity-60"
@@ -39,7 +50,7 @@ const description = "Stay aware of how much of the month has passed with MonthBa
           <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
             <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
           </svg>
-          Coming Soon
+          App Store (Coming Soon)
         </button>
       </div>
 

--- a/src/content/docs/privacy.md
+++ b/src/content/docs/privacy.md
@@ -51,8 +51,7 @@ If this privacy policy changes, the updated policy will be posted at this URL wi
 
 ## Contact
 
-For questions about this privacy policy or the app:
-- GitHub Issues: https://github.com/brightdigit/MonthBar/issues
+For questions about this privacy policy or the app, please visit our [Support page](/support).
 
 ## Consent
 

--- a/src/content/docs/support.md
+++ b/src/content/docs/support.md
@@ -1,0 +1,93 @@
+---
+title: "Support"
+description: "Get help with MonthBar and find answers to common questions"
+lastUpdated: 2026-02-16
+---
+
+# MonthBar Support
+
+Get help with MonthBar, a macOS MenuBar app that tracks your monthly progress.
+
+## Quick Links
+
+- **TestFlight Beta**: [Join the beta program](https://testflight.apple.com/join/N8n1fSPE)
+- **Privacy Policy**: [View our privacy policy](/privacy)
+- **Terms of Use**: [Read the terms](/terms)
+
+## Frequently Asked Questions
+
+### Installation & Setup
+
+**Q: What are the system requirements?**
+A: MonthBar requires macOS 13.0 (Ventura) or later. It's a native SwiftUI app optimized for Apple Silicon and Intel Macs.
+
+**Q: How do I install MonthBar?**
+A: During beta, join via TestFlight. Once released, download from the Mac App Store. After installation, MonthBar will appear in your MenuBar.
+
+**Q: Why doesn't the app appear after installation?**
+A: Check your MenuBar for the MonthBar icon (a pie chart or percentage). If it's hidden, try looking in the MenuBar overflow menu (the three dots).
+
+### Usage
+
+**Q: How do I change the icon style?**
+A: Click the MonthBar icon in your MenuBar, then choose between "Pie Chart" or "Percentage Text" in the settings.
+
+**Q: What's the difference between "Remaining" and "Elapsed" display?**
+A: "Remaining" shows how much of the month is left, while "Elapsed" shows how much has passed. Toggle this in the settings menu.
+
+**Q: How often does the progress update?**
+A: MonthBar updates every 60 seconds automatically. The progress reflects real-time calculations based on your system date and time.
+
+**Q: Does MonthBar work offline?**
+A: Yes! MonthBar is completely offline and never requires an internet connection. All calculations happen locally on your device.
+
+### Privacy & Security
+
+**Q: What data does MonthBar collect?**
+A: None. MonthBar collects zero data. It stores only your display preferences locally and never transmits any information. See our [Privacy Policy](/privacy) for details.
+
+**Q: Does MonthBar use analytics or tracking?**
+A: No. MonthBar has no analytics, no tracking, no crash reporting, and no third-party services.
+
+**Q: Will my settings sync across devices?**
+A: Currently, settings are stored locally per-device using macOS UserDefaults. They do not sync via iCloud or any other service.
+
+### Troubleshooting
+
+**Q: The progress percentage seems wrong**
+A: Ensure your system date and time are set correctly in System Settings. MonthBar uses your system clock for all calculations.
+
+**Q: The MenuBar icon is too small/hard to see**
+A: Try switching between Pie Chart and Percentage Text modes to find what works best for your setup. Percentage Text may be more readable on some displays.
+
+**Q: How do I uninstall MonthBar?**
+A: Quit the app from the MenuBar menu, then delete it from your Applications folder. All local preferences will be removed automatically.
+
+**Q: The app isn't updating to the next month**
+A: MonthBar automatically detects month changes based on your system calendar. If you're experiencing issues, try quitting and restarting the app.
+
+### Beta Testing (TestFlight)
+
+**Q: How do I join the beta?**
+A: Use this TestFlight link: [https://testflight.apple.com/join/N8n1fSPE](https://testflight.apple.com/join/N8n1fSPE)
+
+**Q: How do I report beta bugs?**
+A: Please use the TestFlight feedback feature within the app, or contact us through the support channels listed below. Include your macOS version and a description of the issue.
+
+**Q: When will MonthBar launch on the App Store?**
+A: We're currently in beta testing. Join the TestFlight beta to stay updated on the release timeline.
+
+## Still Need Help?
+
+If you have questions not covered here, please use the TestFlight feedback feature or reach out via email.
+
+**Provide Details**: When reporting issues, include your macOS version, app version, and steps to reproduce any problems.
+
+## Feature Requests
+
+Have an idea to improve MonthBar? We'd love to hear it! Submit feature requests through the TestFlight feedback feature.
+
+---
+
+**Developer**: BrightDigit LLC
+**Website**: https://month.bar

--- a/src/content/docs/terms.md
+++ b/src/content/docs/terms.md
@@ -1,0 +1,80 @@
+---
+title: "Terms of Use"
+description: "MonthBar terms of use and end-user license agreement"
+lastUpdated: 2026-02-16
+---
+
+# Terms of Use for MonthBar
+
+**Effective Date**: February 16, 2026
+**Last Updated**: February 16, 2026
+
+## Acceptance of Terms
+
+By downloading, installing, or using MonthBar ("the App"), you agree to these Terms of Use. If you do not agree, do not use the App.
+
+## License Grant
+
+Subject to your compliance with these terms, BrightDigit LLC grants you a limited, non-exclusive, non-transferable, revocable license to download, install, and use the App for personal, non-commercial use on macOS devices you own or control.
+
+## Permitted Use
+
+You may:
+- Install and use the App on macOS devices you own or control
+- Use the App for personal productivity and time tracking
+- Uninstall the App at any time
+
+## Restrictions
+
+You may not:
+- Modify, reverse engineer, decompile, or disassemble the App
+- Distribute, sublicense, rent, lease, or lend the App
+- Remove or alter any proprietary notices or labels
+- Use the App for any unlawful purpose
+- Attempt to circumvent any security features
+
+## Intellectual Property
+
+The App and all related materials, including but not limited to software, design, graphics, and documentation, are owned by BrightDigit LLC and protected by copyright and other intellectual property laws.
+
+## Warranty Disclaimer
+
+THE APP IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY LAW, BRIGHTDIGIT LLC DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+
+## Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, BRIGHTDIGIT LLC SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY, OR ANY LOSS OF DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES.
+
+## Privacy
+
+Your use of the App is also governed by our [Privacy Policy](/privacy), which is incorporated into these terms by reference.
+
+## Updates and Modifications
+
+BrightDigit LLC may update the App from time to time. These terms apply to all versions and updates. We reserve the right to modify these terms at any time. Continued use after changes constitutes acceptance of the modified terms.
+
+## Termination
+
+Your license to use the App automatically terminates if you violate these terms. Upon termination, you must cease all use and delete all copies of the App.
+
+## Governing Law
+
+These terms are governed by the laws of the United States and the State of Michigan, without regard to conflict of law provisions.
+
+## App Store Terms
+
+If you download the App through the Apple App Store, you also agree to Apple's Licensed Application End User License Agreement (EULA), which can be found at: https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+
+## Contact
+
+For questions about these terms:
+- Support: Visit our [Support page](/support)
+- Website: https://month.bar
+
+## Entire Agreement
+
+These terms, together with the Privacy Policy, constitute the entire agreement between you and BrightDigit LLC regarding the App.
+
+---
+
+© 2026 BrightDigit LLC. All rights reserved.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -77,6 +77,9 @@ const socialImageURL = new URL(image, Astro.site);
               <span class="text-xl font-semibold text-apple-gray-900 dark:text-apple-gray-50">MonthBar</span>
             </a>
             <div class="flex items-center gap-6">
+              <a href="https://testflight.apple.com/join/N8n1fSPE" target="_blank" rel="noopener noreferrer" class="text-apple-gray-700 dark:text-apple-gray-300 hover:text-apple-blue transition-colors">Join TestFlight</a>
+              <a href="/support" class="text-apple-gray-700 dark:text-apple-gray-300 hover:text-apple-blue transition-colors">Support</a>
+              <a href="/terms" class="text-apple-gray-700 dark:text-apple-gray-300 hover:text-apple-blue transition-colors">Terms</a>
               <a href="/privacy" class="text-apple-gray-700 dark:text-apple-gray-300 hover:text-apple-blue transition-colors">Privacy</a>
             </div>
           </div>
@@ -94,6 +97,18 @@ const socialImageURL = new URL(image, Astro.site);
               © 2026 BrightDigit. All rights reserved.
             </div>
             <div class="flex items-center gap-6 text-sm">
+              <a
+                href="/support"
+                class="text-apple-gray-600 dark:text-apple-gray-400 hover:text-apple-blue transition-colors"
+              >
+                Support
+              </a>
+              <a
+                href="/terms"
+                class="text-apple-gray-600 dark:text-apple-gray-400 hover:text-apple-blue transition-colors"
+              >
+                Terms of Use
+              </a>
               <a
                 href="/privacy"
                 class="text-apple-gray-600 dark:text-apple-gray-400 hover:text-apple-blue transition-colors"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,16 +18,24 @@ import Features from '../components/Features.astro';
         <p class="text-lg text-apple-gray-700 dark:text-apple-gray-300 mb-8">
           MonthBar lives quietly in your MenuBar, providing instant awareness of your monthly progress. Perfect for goal tracking, budget period awareness, and project deadline visualization.
         </p>
-        <div class="flex justify-center">
-          <button
-            disabled
-            class="inline-flex items-center gap-2 px-8 py-4 bg-apple-gray-200 dark:bg-apple-gray-700 text-apple-gray-500 dark:text-apple-gray-400 rounded-xl font-semibold cursor-not-allowed opacity-60"
+        <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
+          <a
+            href="https://testflight.apple.com/join/N8n1fSPE"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 px-8 py-4 bg-apple-blue hover:bg-apple-blue/90 text-white rounded-xl font-semibold transition-colors"
           >
             <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
               <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
             </svg>
-            Coming Soon to App Store
-          </button>
+            Join TestFlight Beta
+          </a>
+          <a
+            href="/support"
+            class="inline-flex items-center gap-2 px-8 py-4 bg-apple-gray-100 dark:bg-apple-gray-800 text-apple-gray-900 dark:text-apple-gray-100 hover:bg-apple-gray-200 dark:hover:bg-apple-gray-700 rounded-xl font-semibold transition-colors"
+          >
+            Learn More
+          </a>
         </div>
       </div>
     </div>

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -1,0 +1,11 @@
+---
+import { getEntry } from 'astro:content';
+import ContentLayout from '../layouts/ContentLayout.astro';
+
+const entry = await getEntry('docs', 'support');
+const { Content } = await entry.render();
+---
+
+<ContentLayout title="Support" description={entry.data.description}>
+  <Content />
+</ContentLayout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,11 @@
+---
+import { getEntry } from 'astro:content';
+import ContentLayout from '../layouts/ContentLayout.astro';
+
+const entry = await getEntry('docs', 'terms');
+const { Content } = await entry.render();
+---
+
+<ContentLayout title="Terms of Use" description={entry.data.description}>
+  <Content />
+</ContentLayout>


### PR DESCRIPTION
## Summary
Implements issues #12, #13, and #14 by adding essential pages and TestFlight integration to the website.

## Changes

### New Pages
- ✅ **Support Page** (#13) - Comprehensive FAQ covering installation, usage, privacy, troubleshooting, and beta testing
- ✅ **Terms of Use** (#12) - Complete EULA with license terms, restrictions, warranties, and liability disclaimers

### TestFlight Integration (#14)
- **Navigation Bar**: Added "Join TestFlight" link alongside Support, Terms, and Privacy
- **Hero Section**: Added prominent "Join TestFlight Beta" button with App Store coming soon indicator
- **Bottom CTA**: Replaced disabled button with active TestFlight button + "Learn More" secondary button
- **Footer**: Added Support and Terms links

### Content Updates
- Removed GitHub Issues references (private repository)
- Removed Work Days mode FAQ (feature not yet implemented)
- Updated all contact links to point to Support page or TestFlight feedback
- Updated Privacy and Terms pages to reference Support page

## Testing
- ✅ Build successful (`npm run build`)
- ✅ All pages generate correctly
- ✅ Navigation links functional
- ✅ TestFlight links open in new tab with proper `rel="noopener noreferrer"`

## Pages Added
- `/support` - Support and FAQ page
- `/terms` - Terms of Use page

## Files Changed
- `src/components/Hero.astro` - Add TestFlight button
- `src/layouts/BaseLayout.astro` - Update navigation and footer
- `src/pages/index.astro` - Update bottom CTA with TestFlight link
- `src/content/docs/support.md` - New support content
- `src/content/docs/terms.md` - New terms content
- `src/pages/support.astro` - New support page
- `src/pages/terms.astro` - New terms page
- `src/content/docs/privacy.md` - Update contact links

Closes #12, #13, #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/month.bar/15)
<!-- GitContextEnd -->