### PR TITLE
Fix color-contrast failures on press page for WCAG AA

### DIFF
--- a/src/components/ColorSwatch.astro
+++ b/src/components/ColorSwatch.astro
@@ -15,7 +15,7 @@ const { name, hex, usage } = Astro.props;
   ></div>
   <div>
     <p class="font-semibold text-apple-gray-900 dark:text-apple-gray-50">{name}</p>
-    <p class="text-sm font-mono text-apple-gray-600 dark:text-apple-gray-400">{hex}</p>
-    <p class="text-sm text-apple-gray-500 dark:text-apple-gray-400 mt-1">{usage}</p>
+    <p class="text-sm font-mono text-apple-gray-600 dark:text-apple-gray-300">{hex}</p>
+    <p class="text-sm text-apple-gray-500 dark:text-apple-gray-300 mt-1">{usage}</p>
   </div>
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -127,7 +127,7 @@ const schemaData = {
       <footer class="border-t border-apple-gray-200 dark:border-apple-gray-800 mt-16">
         <div class="container py-8">
           <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-            <div class="text-sm text-apple-gray-600 dark:text-apple-gray-400">
+            <div class="text-sm text-apple-gray-600 dark:text-apple-gray-300">
               © 2026 BrightDigit. All rights reserved.
             </div>
             <div class="flex items-center gap-6 text-sm">
@@ -135,31 +135,31 @@ const schemaData = {
                 href="https://testflight.apple.com/join/N8n1fSPE"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="text-apple-gray-600 dark:text-apple-gray-400 hover:text-apple-blue transition-colors"
+                class="text-apple-gray-600 dark:text-apple-gray-300 hover:text-apple-blue transition-colors"
               >
                 Join TestFlight
               </a>
               <a
                 href="/press"
-                class="text-apple-gray-600 dark:text-apple-gray-400 hover:text-apple-blue transition-colors"
+                class="text-apple-gray-600 dark:text-apple-gray-300 hover:text-apple-blue transition-colors"
               >
                 Press Kit
               </a>
               <a
                 href="/support"
-                class="text-apple-gray-600 dark:text-apple-gray-400 hover:text-apple-blue transition-colors"
+                class="text-apple-gray-600 dark:text-apple-gray-300 hover:text-apple-blue transition-colors"
               >
                 Support
               </a>
               <a
                 href="/terms"
-                class="text-apple-gray-600 dark:text-apple-gray-400 hover:text-apple-blue transition-colors"
+                class="text-apple-gray-600 dark:text-apple-gray-300 hover:text-apple-blue transition-colors"
               >
                 Terms of Use
               </a>
               <a
                 href="/privacy"
-                class="text-apple-gray-600 dark:text-apple-gray-400 hover:text-apple-blue transition-colors"
+                class="text-apple-gray-600 dark:text-apple-gray-300 hover:text-apple-blue transition-colors"
               >
                 Privacy Policy
               </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,7 +39,7 @@ import Features from '../components/Features.astro';
             href="/support"
             class="inline-flex items-center gap-2 px-8 py-4 bg-apple-gray-100 dark:bg-apple-gray-800 text-apple-gray-900 dark:text-apple-gray-100 hover:bg-apple-gray-200 dark:hover:bg-apple-gray-700 rounded-xl font-semibold transition-colors"
           >
-            Learn More
+            Support & FAQ
           </a>
         </div>
       </div>

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -42,7 +42,7 @@ const screenshots = [
         <h1 class="text-4xl md:text-5xl font-bold mb-4 text-apple-gray-900 dark:text-apple-gray-50">
           Press Kit
         </h1>
-        <p class="text-lg text-apple-gray-600 dark:text-apple-gray-400 mb-8">
+        <p class="text-lg text-apple-gray-600 dark:text-apple-gray-300 mb-8">
           Everything you need to write about MonthBar. Download brand assets, screenshots, and app information.
         </p>
         <a
@@ -71,7 +71,7 @@ const screenshots = [
       ].map(([title, desc]) => (
         <li class="bg-white dark:bg-apple-gray-800 p-4 rounded-xl border border-apple-gray-200 dark:border-apple-gray-700">
           <p class="font-semibold text-apple-gray-900 dark:text-apple-gray-50 mb-1">{title}</p>
-          <p class="text-sm text-apple-gray-600 dark:text-apple-gray-400">{desc}</p>
+          <p class="text-sm text-apple-gray-600 dark:text-apple-gray-300">{desc}</p>
         </li>
       ))}
     </ul>
@@ -83,25 +83,25 @@ const screenshots = [
       {iconAppearances.map(({ name, prefix }) => (
         <div class="text-center">
           <picture>
-            <source srcset={`/images/app-icon/${prefix}-1024.webp`} type="image/webp" />
+            <source srcset={`/images/app-icon/${prefix}-512.webp`} type="image/webp" />
             <img
-              src={`/images/app-icon/${prefix}-1024.png`}
+              src={`/images/app-icon/${prefix}-512.png`}
               alt={`MonthBar App Icon — ${name}`}
-              width="1024"
-              height="1024"
-              class="w-40 h-40 rounded-3xl shadow-lg mx-auto mb-4"
+              width="160"
+              height="160"
+              class="w-40 max-w-full aspect-square rounded-3xl shadow-lg mx-auto mb-4"
               loading="lazy"
             />
           </picture>
           <p class="font-medium text-apple-gray-900 dark:text-apple-gray-50 mb-1">{name}</p>
           <div class="flex gap-3 justify-center text-sm">
-            <span class="text-apple-gray-500">1024:
-              <a href={`/images/app-icon/${prefix}-1024.png`} download class="text-apple-blue hover:underline">PNG</a>
-              <a href={`/images/app-icon/${prefix}-1024.webp`} download class="text-apple-blue hover:underline">WebP</a>
+            <span class="text-apple-gray-500 dark:text-apple-gray-300">1024:
+              <a href={`/images/app-icon/${prefix}-1024.png`} download class="text-apple-blue dark:text-dark-mode-blue hover:underline">PNG</a>
+              <a href={`/images/app-icon/${prefix}-1024.webp`} download class="text-apple-blue dark:text-dark-mode-blue hover:underline">WebP</a>
             </span>
-            <span class="text-apple-gray-500">512:
-              <a href={`/images/app-icon/${prefix}-512.png`} download class="text-apple-blue hover:underline">PNG</a>
-              <a href={`/images/app-icon/${prefix}-512.webp`} download class="text-apple-blue hover:underline">WebP</a>
+            <span class="text-apple-gray-500 dark:text-apple-gray-300">512:
+              <a href={`/images/app-icon/${prefix}-512.png`} download class="text-apple-blue dark:text-dark-mode-blue hover:underline">PNG</a>
+              <a href={`/images/app-icon/${prefix}-512.webp`} download class="text-apple-blue dark:text-dark-mode-blue hover:underline">WebP</a>
             </span>
           </div>
         </div>
@@ -111,7 +111,7 @@ const screenshots = [
 
   <!-- Screenshots -->
   <PressSection title="Screenshots" id="screenshots">
-    <p class="text-apple-gray-600 dark:text-apple-gray-400 mb-8">
+    <p class="text-apple-gray-600 dark:text-apple-gray-300 mb-8">
       Screenshots available in both light and dark mode variants.
     </p>
 
@@ -122,10 +122,12 @@ const screenshots = [
           <img
             src={`/images/screenshots/light-mode/${file}.webp`}
             alt={`MonthBar light mode — ${caption}`}
+            width="2560"
+            height="1600"
             class="rounded-lg shadow-md border border-apple-gray-200 dark:border-apple-gray-700 w-full"
             loading="lazy"
           />
-          <figcaption class="text-xs text-apple-gray-500 dark:text-apple-gray-400 mt-2 text-center">{caption}</figcaption>
+          <figcaption class="text-xs text-apple-gray-500 dark:text-apple-gray-300 mt-2 text-center">{caption}</figcaption>
         </figure>
       ))}
     </div>
@@ -137,10 +139,12 @@ const screenshots = [
           <img
             src={`/images/screenshots/dark-mode/${file}.webp`}
             alt={`MonthBar dark mode — ${caption}`}
+            width="2560"
+            height="1600"
             class="rounded-lg shadow-md border border-apple-gray-200 dark:border-apple-gray-700 w-full"
             loading="lazy"
           />
-          <figcaption class="text-xs text-apple-gray-500 dark:text-apple-gray-400 mt-2 text-center">{caption}</figcaption>
+          <figcaption class="text-xs text-apple-gray-500 dark:text-apple-gray-300 mt-2 text-center">{caption}</figcaption>
         </figure>
       ))}
     </div>
@@ -154,7 +158,7 @@ const screenshots = [
           <h3 class="text-lg font-semibold text-apple-gray-900 dark:text-apple-gray-50">Short Description</h3>
           <button
             data-copy="short"
-            class="text-sm text-apple-blue hover:underline cursor-pointer"
+            class="text-sm text-apple-blue dark:text-dark-mode-blue hover:underline cursor-pointer"
           >
             Copy
           </button>
@@ -168,7 +172,7 @@ const screenshots = [
           <h3 class="text-lg font-semibold text-apple-gray-900 dark:text-apple-gray-50">Long Description</h3>
           <button
             data-copy="long"
-            class="text-sm text-apple-blue hover:underline cursor-pointer"
+            class="text-sm text-apple-blue dark:text-dark-mode-blue hover:underline cursor-pointer"
           >
             Copy
           </button>
@@ -196,21 +200,21 @@ const screenshots = [
           <div class="flex px-6 py-3">
             <dt class="w-32 shrink-0 font-medium text-apple-gray-900 dark:text-apple-gray-50">{term}</dt>
             <dd class="text-apple-gray-700 dark:text-apple-gray-300">
-              {term === 'Website' ? <a href={def} class="text-apple-blue hover:underline">{def}</a> : def}
+              {term === 'Website' ? <a href={def} class="text-apple-blue dark:text-progress-green hover:underline">{def}</a> : def}
             </dd>
           </div>
         ))}
         <div class="flex px-6 py-3">
           <dt class="w-32 shrink-0 font-medium text-apple-gray-900 dark:text-apple-gray-50">TestFlight</dt>
           <dd>
-            <a href="https://testflight.apple.com/join/N8n1fSPE" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">
+            <a href="https://testflight.apple.com/join/N8n1fSPE" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-progress-green hover:underline">
               Join Beta
             </a>
           </dd>
         </div>
         <div class="flex px-6 py-3">
           <dt class="w-32 shrink-0 font-medium text-apple-gray-900 dark:text-apple-gray-50">App Store</dt>
-          <dd class="text-apple-gray-500 dark:text-apple-gray-400">Coming Soon</dd>
+          <dd class="text-apple-gray-500 dark:text-apple-gray-300">Coming Soon</dd>
         </div>
       </dl>
     </div>
@@ -238,7 +242,7 @@ const screenshots = [
         <p class="text-apple-gray-700 dark:text-apple-gray-300">
           MonthBar uses the system font stack for a native feel:
         </p>
-        <p class="mt-2 font-mono text-sm text-apple-gray-600 dark:text-apple-gray-400 bg-white dark:bg-apple-gray-800 p-3 rounded-lg border border-apple-gray-200 dark:border-apple-gray-700">
+        <p class="mt-2 font-mono text-sm text-apple-gray-600 dark:text-apple-gray-300 bg-white dark:bg-apple-gray-800 p-3 rounded-lg border border-apple-gray-200 dark:border-apple-gray-700">
           -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif
         </p>
       </div>
@@ -253,26 +257,26 @@ const screenshots = [
           MonthBar is made by <strong class="text-apple-gray-900 dark:text-apple-gray-50">BrightDigit</strong>, an independent software studio founded by <strong class="text-apple-gray-900 dark:text-apple-gray-50">Leo Dion</strong> specializing in native Apple platform apps. BrightDigit focuses on building thoughtful, privacy-respecting tools for macOS and iOS.
         </p>
         <div class="flex flex-wrap gap-4 text-sm">
-          <a href="https://brightdigit.com" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">Website</a>
-          <a href="https://x.com/brightdigit" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">Twitter</a>
-          <a href="https://github.com/brightdigit" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">GitHub</a>
-          <a href="https://www.youtube.com/@brightdigit" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">YouTube</a>
+          <a href="https://brightdigit.com" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-dark-mode-blue hover:underline">Website</a>
+          <a href="https://x.com/brightdigit" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-dark-mode-blue hover:underline">Twitter</a>
+          <a href="https://github.com/brightdigit" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-dark-mode-blue hover:underline">GitHub</a>
+          <a href="https://www.youtube.com/@brightdigit" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-dark-mode-blue hover:underline">YouTube</a>
         </div>
       </div>
 
       <div>
         <h3 class="text-lg font-semibold mb-3 text-apple-gray-900 dark:text-apple-gray-50">About Me</h3>
         <p class="text-apple-gray-700 dark:text-apple-gray-300 mb-3">
-          Leo Dion is the founder of BrightDigit, a full-stack Swift development company he's been running since 2012. He specializes in end-to-end Swift solutions — from iOS, macOS, and watchOS to server-side Swift — and has shipped multiple App Store apps including <a href="https://getbushel.app" class="text-apple-blue hover:underline">Bushel</a> (macOS virtualization for developers) and Heartwitch (Apple Watch health streaming).
+          Leo Dion is the founder of BrightDigit, a full-stack Swift development company he's been running since 2012. He specializes in end-to-end Swift solutions — from iOS, macOS, and watchOS to server-side Swift — and has shipped multiple App Store apps including <a href="https://getbushel.app" class="text-apple-blue dark:text-dark-mode-blue underline">Bushel</a> (macOS virtualization for developers) and Heartwitch (Apple Watch health streaming).
         </p>
         <p class="text-apple-gray-700 dark:text-apple-gray-300 mb-4">
-          Leo is an active open source contributor, hosts <a href="https://empowerapps.show" class="text-apple-blue hover:underline">EmpowerApps.show</a>, and has been speaking about Swift since its launch. He lives in Michigan with his wife Betsy and six kids.
+          Leo is an active open source contributor, hosts <a href="https://empowerapps.show" class="text-apple-blue dark:text-dark-mode-blue underline">EmpowerApps.show</a>, and has been speaking about Swift since its launch. He lives in Michigan with his wife Betsy and six kids.
         </p>
         <div class="flex flex-wrap gap-4 text-sm">
-          <a href="https://x.com/leogdion" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">Twitter</a>
-          <a href="https://github.com/leogdion" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">GitHub</a>
-          <a href="https://www.linkedin.com/in/leogdion/" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">LinkedIn</a>
-          <a href="https://c.im/@leogdion" target="_blank" rel="noopener noreferrer" class="text-apple-blue hover:underline">Mastodon</a>
+          <a href="https://x.com/leogdion" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-dark-mode-blue hover:underline">Twitter</a>
+          <a href="https://github.com/leogdion" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-dark-mode-blue hover:underline">GitHub</a>
+          <a href="https://www.linkedin.com/in/leogdion/" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-dark-mode-blue hover:underline">LinkedIn</a>
+          <a href="https://c.im/@leogdion" target="_blank" rel="noopener noreferrer" class="text-apple-blue dark:text-dark-mode-blue hover:underline">Mastodon</a>
         </div>
       </div>
     </div>
@@ -284,7 +288,7 @@ const screenshots = [
       <p class="text-apple-gray-700 dark:text-apple-gray-300 mb-4">
         For press inquiries, please reach out via email.
       </p>
-      <a href="mailto:press@month.bar" class="text-apple-blue hover:underline font-medium mb-6 inline-block">
+      <a href="mailto:press@month.bar" class="text-apple-blue dark:text-dark-mode-blue hover:underline font-medium mb-6 inline-block">
         press@month.bar
       </a>
     </div>


### PR DESCRIPTION
## Summary

- Replace `apple-blue-accessible` with `text-apple-blue dark:text-dark-mode-blue` using named Tailwind tokens from config
- Fix Fact Sheet links (rendered on `dark:bg-apple-gray-800` / #2c2c2e) to use `dark:text-progress-green` (#34C759 = 6.19:1 contrast ✓), since `#0A84FF` only achieves 3.82:1 on that background
- Upgrade `dark:text-apple-gray-400` → `dark:text-apple-gray-300` throughout `press.astro`, `ColorSwatch.astro`, and `BaseLayout.astro`
- Resolve `tailwind.config.mjs` merge conflict, keeping `dark-mode-blue` (#0A84FF) and `progress-green` (#34C759) tokens

## Test plan

- [ ] Run Lighthouse on `/press` in dark mode — `color-contrast` audit should pass (score 1.0)
- [ ] Accessibility score should reach 1.0 (was 0.94)
- [ ] Verify Fact Sheet links render in green in dark mode
- [ ] Verify all other links render in `#0A84FF` blue in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/month.bar/34)
<!-- GitContextEnd -->